### PR TITLE
Added basedir to jade compile options

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -116,6 +116,7 @@ module.exports = class StaticJadeCompiler
           throw err
 
         @options.filename = jadeFilePath
+        @options.basedir = sysPath.join '.', 'app'
 
         fn = jade.compile data,
           @options


### PR DESCRIPTION
To support relative extension and inclusion (with a leading slash). See https://github.com/visionmedia/jade/pull/989
