### PR TITLE
When dependecy has not main in package.json plugin fail on brunch load. ...

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -39,7 +39,12 @@ loadPackages = (rootPath, callback) ->
     json = JSON.parse(data)
     deps = Object.keys(extend(json.devDependencies ? {}, json.dependencies))
     try
-      plugins = deps.map (dependency) -> require "#{nodeModules}/#{dependency}"
+      plugins = deps.map (dependency) -> 
+        try
+          require "#{nodeModules}/#{dependency}"
+        catch err
+          {}
+          
     catch err
       error = err
     callback error, plugins


### PR DESCRIPTION
In my project I include grunt dependencies and grunt-cli has no "main" in package.json, it has only bin script. On compile project I have log:

```
/Users/dominik.lubanski/Workspace/ingest/node_modules/bower/node_modules/tmp/lib/tmp.js:261
  throw err;
        ^
Error: Cannot find module '/Users/dominik.lubanski/Workspace/ingest/node_modules/grunt-cli'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /Users/dominik.lubanski/Workspace/ingest/node_modules/static-jade-brunch/lib/index.js:77:20
    at Array.map (native)
    at /Users/dominik.lubanski/Workspace/ingest/node_modules/static-jade-brunch/lib/index.js:76:24
    at fs.js:266:14
    at /Users/dominik.lubanski/Workspace/ingest/node_modules/brunch/node_modules/init-skeleton/node_modules/rimraf/node_modules/graceful-fs/graceful-fs.js:103:5
    at Object.oncomplete (fs.js:107:15)
npm ERR! weird error 7
npm ERR! not ok code 0
```

Mapping dependecies should be called with try/catch, and return empty object when it fails.
