### PR TITLE
Fixes for Node.js 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "static-jade-brunch",
-  "version": "1.7.0",
-  "description": "Adds Jade support to Brunch without wrapping the compiled html in modules of type commonjs/amd. With it you can get rid of index.html and use index.jade instead.",
+  "version": "1.7.1",
   "author": {
     "name": "Costantino Giuliodori (ilkosta)"
   },
@@ -12,19 +11,16 @@
   },
   "main": "./lib/index",
   "scripts": {
-    "prepublish": "coffee -o lib/ src/",
+    "prepublish": "node setup.js prepublish",
     "postinstall": "node setup.js postinstall",
     "test": "node setup.js test"
   },
-  "engines": {
-    "node": "~0.6.10 || 0.8 || 0.9 || 0.10"
-  },
   "dependencies": {
-    "coffee-script": "1.3.3",
-    "jade":          "*",
-    "mkdirp":        "*",
-    "ansi-color":    "~0.2.1",
-    "growl":         "~1.6.0"
+    "coffee-script": "~1.3.3",
+    "jade": "*",
+    "mkdirp": "*",
+    "ansi-color": "~0.2.1",
+    "growl": "~1.6.0"
   },
   "devDependencies": {
     "mocha": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "static-jade-brunch",
   "version": "1.7.1",
+  "description": "Adds Jade support to Brunch, without wrapping the compiled HTML into modules.",
   "author": {
     "name": "Costantino Giuliodori (ilkosta)"
   },
+  "license": "MIT",
   "homepage": "https://github.com/ilkosta/static-jade-brunch",
+  "bugs": "https://github.com/ilkosta/static-jade-brunch/issues",
   "repository": {
     "type": "git",
     "url": "git@github.com:ilkosta/static-jade-brunch.git"

--- a/setup.js
+++ b/setup.js
@@ -1,4 +1,4 @@
-var exec = require('child_process').exec;
+var child_process = require('child_process'), exec = child_process.exec, spawn = child_process.spawn;
 var sysPath = require('path');
 var fs = require('fs');
 
@@ -17,7 +17,13 @@ var execute = function(pathParts, params, callback) {
   });
 };
 
-if (mode === 'postinstall') {
+if (mode === 'prepublish') {
+  var coffee = __dirname + '/node_modules/coffee-script/bin/coffee';
+  spawn('node', [coffee, '-o', 'lib', '-c', 'src'], {
+    cwd: __dirname,
+    stdio: 'inherit'
+  });
+} else if (mode === 'postinstall') {
   fsExists(sysPath.join(__dirname, 'lib'), function(exists) {
     if (exists) return;
     execute(['node_modules', 'coffee-script', 'bin', 'coffee'], '-o lib/ src/');


### PR DESCRIPTION
This PR contains:
- A fix to actually use the specified version of CoffeeScript instead of the globally installed one (fixes issues for Node.js 0.12)
- Some tweaks to `package.json` (license, bugs link)

Regards