### PR TITLE
Deprecated static-jade-brunch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
+> ## 🚧 This Plugin Is Deprecated 🚧
+
+> This plugins is deprecated, since Brunch Static APIs are deprecated.
+
+# static-jade-brunch
+
 [![build status](https://secure.travis-ci.org/ilkosta/static-jade-brunch.png)](http://travis-ci.org/ilkosta/static-jade-brunch)
 
-## static-jade-brunch
 Adds [Jade](http://jade-lang.com) support to [brunch](http://brunch.io) without wrapping the compiled html in modules of type commonjs/amd.
 
 With it you can get rid of `index.html` and use `index.jade` instead.


### PR DESCRIPTION
We're going to delete static-jade-brunch repo from Brunch's org as soon as you merge this PR.

P.S: Please, do not deprecated this plugin on NPM. Let's do not bother our users with useless warnings in logs.